### PR TITLE
BOJ 1967 skyqnaqna

### DIFF
--- a/기본 문제/11주차_트리/1967_트리의 지름/skyqnaqna.swift
+++ b/기본 문제/11주차_트리/1967_트리의 지름/skyqnaqna.swift
@@ -1,0 +1,50 @@
+/*
+ 백준 1967 트리의 지름
+ 21.08.27
+ https://github.com/skyqnaqna/algorithm_study
+ */
+
+import Foundation
+
+let n = Int(readLine()!)!
+
+var nodes = [[(next: Int, w: Int)]](repeating: [(Int, Int)](), count: n + 1)
+var visited = [Bool](repeating: false, count: n + 1)
+
+// 가정 먼 거리와 가장 먼 노드
+var ans = 0, farNode = 0
+
+for _ in 0 ..< n - 1 {
+  let edge = readLine()!.split(separator: " ").map { Int(String($0))! }
+  let u = edge[0], v = edge[1], w = edge[2]
+
+  nodes[u].append((v, w))
+  nodes[v].append((u, w))
+}
+
+func dfs(_ now: Int, _ dist: Int) {
+  if dist > ans {
+    ans = dist
+    farNode = now
+  }
+
+  for node in nodes[now] {
+    if !visited[node.next] {
+      visited[node.next] = true
+      dfs(node.next, dist + node.w)
+      visited[node.next] = false
+    }
+  }
+}
+
+// 아무 점에서 시작해서 가장 먼 노드를 구한다
+visited[1] = true
+dfs(1, 0)
+ans = 0
+
+// 다시 ans와 vistied를 초기화하고 이전에 구한 노드에서 시작하여 가장 먼 노드를 구한다
+visited = [Bool](repeating: false, count: n + 1)
+visited[farNode] = true
+dfs(farNode, 0)
+
+print(ans)


### PR DESCRIPTION
처음에 풀었던 방식은 모든 리프노드에서 시작하여 bfs탐색을 통해 가장 먼 거리를 구했습니다.
하지만 시간이 너무 오래걸려서 어떻게 줄일지 검색해보니 
1. 트리의 지름을 구하기 위해 임의의 점에서 가장 먼 거리에 있는 u를 구하고
2. 다시 u에서 시작하여 가장 먼 거리를 구하면 되는 것이였습니다.

그래서 다시 dfs를 2번 사용하여 제출했더니 1888ms -> 36ms 로 줄었습니다.

아래는 첫 번째 방식으로 푼 풀이입니다.

```swift
import Foundation

let n = Int(readLine()!)!

var nodes = [[(next: Int, w: Int)]](repeating: [(Int, Int)](), count: n + 1)
var used = [Bool](repeating: false, count: n + 1) // 리프노드 중에서 시작점으로 사용한 것은 true
var visited = [Bool](repeating: false, count: n + 1) // bfs 탐색 시 방문노드 체크
var ans = 0

for _ in 0 ..< n - 1 {
  let edge = readLine()!.split(separator: " ").map { Int(String($0))! }
  let u = edge[0], v = edge[1], w = edge[2]

  nodes[u].append((v, w))
  nodes[v].append((u, w))
}

func reset() {
  visited = [Bool](repeating: false, count: n + 1)
}

// node는 리프노드와 연결된 노드 = 부모 노드
func getRadius(_ node: Int, _ cost: Int) {
  var q = [(Int, Int)](), front = 0
  q.append((node, cost))
  visited[node] = true

  while front < q.count {
    let (now, dist) = q[front]
    front += 1

    // 도달한 노드가 리프노드이면 지름이 될 수 있음
    if nodes[now].count == 1 {
      ans = max(ans, dist)
      continue
    }

    for node in nodes[now] {
      if !visited[node.next] && !used[node.next] {
        q.append((node.next, dist + node.w))
        visited[node.next] = true
      }
    }
  }
}

for i in 1 ... n {
  // !used[i]가 없으면 시간초과 발생
  // 반복문안에서 선형탐색이기 때문에 없어도 될 것이라고 생각했지만 이유는 아직 모르겠음
  if !used[i] && nodes[i].count == 1 {
    reset()
    visited[i] = true
    used[i] = true
    getRadius(nodes[i][0].next, nodes[i][0].w)
  }
}

print(ans)
```